### PR TITLE
Setup permissions for container-internal directories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,12 +35,13 @@ RUN \
 	openldap-dev && \
 	\
 	\
-	echo 'creating directories' && \
-	mkdir -p /app /run/nginx /run/postgresql /var/log/funkwhale && \
-	\
-	\
 	echo 'creating users' && \
 	adduser -s /bin/false -D -H funkwhale funkwhale && \
+	\
+	\
+	echo 'creating directories' && \
+	mkdir -p /app/api /run/nginx /run/postgresql /var/log/funkwhale && \
+	chown funkwhale:funkwhale /app/api /var/log/funkwhale && \
 	\
 	\
 	echo 'downloading archives' && \


### PR DESCRIPTION
After #44, some internal directories created in the Dockerfile will end up with the wrong permissions. This should be sufficient all errors I observed.

(/var/log/funkwhale is obvious; /app/api/ is required for celery to create /app/api/celerybeat-schedule with the right user)