### PR TITLE
Expose port 80.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.10
 MAINTAINER thetarkus
 
+EXPOSE 80
 
 #
 # Installation


### PR DESCRIPTION
Allows solutions using https://github.com/nginx-proxy/nginx-proxy to avoid having to make the localhost binding.